### PR TITLE
Fix bug in parse_requirements call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     version="0.1",
     packages=find_packages(),
     description="Toolkit for sonar signal processing",
-    install_reqs = parse_requirements('requirements.txt')
+    install_reqs = parse_requirements('requirements.txt', session=False)
 )


### PR DESCRIPTION
Due to the new versions of PIP, when trying to install using the following command I notice an error:
```bash
$ pip install git+https://github.com/pedrolisboa/poseidon
```

Error:

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-bml60bki/setup.py", line 14, in <module>
        install_reqs = parse_requirements('requirements.txt')
    TypeError: parse_requirements() missing 1 required positional argument: 'session'
```